### PR TITLE
Comments out loop header if its body is commented out.

### DIFF
--- a/Sources/Layers/VMKChordLayer.mm
+++ b/Sources/Layers/VMKChordLayer.mm
@@ -79,7 +79,7 @@ using namespace mxml;
 
 - (void)setActiveForegroundColor:(VMKColor*)foregroundColor {
     [super setActiveForegroundColor:foregroundColor];
-    for (VMKNoteHeadLayer* layer in _noteHeadLayers)
+//    for (VMKNoteHeadLayer* layer in _noteHeadLayers)
 //        layer.activeForegroundColor = foregroundColor;
     for (VMKScoreElementLayer* layer in _otherLayers)
         layer.activeForegroundColor = foregroundColor;


### PR DESCRIPTION
I don't understand why loop body was commented out.
But keeping loop header not commented out along with its body changes logic completely.